### PR TITLE
Add `Contains<T>` method to `RArray<T>` interface

### DIFF
--- a/rethinkdb.d.ts
+++ b/rethinkdb.d.ts
@@ -34,6 +34,7 @@ declare namespace rethinkdb {
     r.Add<r.ArrayLike<T>>,
     r.Append<T>,
     r.ChangeAt<T>,
+    r.Contains<T>,
     r.DeleteAt<T>,
     r.Difference<T>,
     r.InsertAt<T>,


### PR DESCRIPTION
`.contains()` should be available off `.dbList() : RArray<T>` as mentioned in the second example of [rethinkdb/rethinkdb #3512](https://github.com/rethinkdb/rethinkdb/issues/3512).  